### PR TITLE
Run Command tests for .exec_() as well

### DIFF
--- a/pydexec/tests/test_command.py
+++ b/pydexec/tests/test_command.py
@@ -21,48 +21,63 @@ def parse_env_output(out_lines):
     return cmd_env
 
 
-class _CommonCommandTests(object):
+def run_cmd(cmd):
+    return cmd.run()
+
+
+def exec_cmd(cmd):
+    # Run the command in a separate process so that it can be exec-ed
+    p = Process(target=cmd.exec_)
+    p.start()
+    p.join()
+    if p.exitcode:
+        # Simulate a CalledProcessError to simplify tests
+        raise CalledProcessError(p.exitcode, [cmd._program] + cmd._args)
+    return p.exitcode
+
+
+class TestCommand(object):
     # Use pytest-style tests rather than testtools so that we can capture
     # stdout/stderr from the file descriptors.
 
-    def execute(self, cmd):
-        """ Execute the given Command object. """
-        raise NotImplementedError()  # pragma: no cover
+    @pytest.fixture(scope='class', params=[run_cmd, exec_cmd])
+    def runner(self, request):
+        return request.param
 
-    def test_stdout(self, capfd):
+    def test_stdout(self, capfd, runner):
         """
         When a command writes to stdout, that output should be captured and
         written to Python's stdout.
         """
-        self.execute(Command('echo').args('Hello, World!'))
+        runner(Command('echo').args('Hello, World!'))
 
         out_lines, err_lines = captured_lines(capfd)
         assert_that(out_lines, Equals(['Hello, World!']))
         assert_that(err_lines, Equals([]))
 
-    def test_stderr(self, capfd):
+    def test_stderr(self, capfd, runner):
         """
         When a command writes to stderr, that output should be captured and
         written to Python's stderr.
         """
-        self.execute(Command('awk')
-                     .args('BEGIN { print "Hello, World!" > "/dev/stderr" }'))
+        runner(Command('awk')
+               .args('BEGIN { print "Hello, World!" > "/dev/stderr" }'))
 
         out_lines, err_lines = captured_lines(capfd)
         assert_that(out_lines, Equals([]))
         assert_that(err_lines, Equals(['Hello, World!']))
 
-    def test_output_unicode(self, capfd):
+    def test_output_unicode(self, capfd, runner):
         """
         When a command writes Unicode to a standard stream, that output should
         be captured and encoded correctly.
         """
-        self.execute(Command('echo').args('á, é, í, ó, ú, ü, ñ, ¿, ¡'))
+        runner(Command('echo').args('á, é, í, ó, ú, ü, ñ, ¿, ¡'))
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['á, é, í, ó, ú, ü, ñ, ¿, ¡']))
 
-    def test_error(self, capfd):
+    def test_error(self, capfd, runner):
         """
         When a command exits with a non-zero return code, an error should be
         raised with the correct information about the result of the command.
@@ -71,19 +86,18 @@ class _CommonCommandTests(object):
         with ExpectedException(
             CalledProcessError,
                 'Command .*awk.* returned non-zero exit status 1'):
-            self.execute(
-                Command('awk').args('BEGIN { print "errored"; exit 1 }'))
+            runner(Command('awk').args('BEGIN { print "errored"; exit 1 }'))
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['errored']))
 
-    def test_preserves_environment(self, capfd):
+    def test_preserves_environment(self, capfd, runner):
         """
         When a command is run, the environment variables of the parent process
         are preserved.
         """
         env = dict(os.environ)
-        self.execute(Command('env'))
+        runner(Command('env'))
 
         out_lines, _ = captured_lines(capfd)
         cmd_env = parse_env_output(out_lines)
@@ -91,7 +105,7 @@ class _CommonCommandTests(object):
         assert_that(cmd_env, Equals(env))
 
     @pytest.mark.skipif(os.getuid() != 0, reason='requires root')
-    def test_switch_user(self, capfd):
+    def test_switch_user(self, capfd, runner):
         """
         When a user is set for the command, the user should be switched to
         before the command is run.
@@ -99,19 +113,19 @@ class _CommonCommandTests(object):
         cmd = (Command('/bin/sh')
                .args('-c', 'echo "$(id -u):$(id -g):$(id -G)"')
                .user('1000:1000'))
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['1000:1000:1000']))
 
         # Check that we can still run as other users (haven't demoted whole
         # Python process to non-root user)
-        self.execute(cmd.user('0:0'))
+        runner(cmd.user('0:0'))
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['0:0:0']))
 
     @pytest.mark.skipif(os.getuid() != 0, reason='requires root')
-    def test_switch_user_preserves_environment(self, capfd):
+    def test_switch_user_preserves_environment(self, capfd, runner):
         """
         When a command is run and a user is set, the environment variables of
         the parent process are preserved, except for the ``HOME`` variable
@@ -119,7 +133,7 @@ class _CommonCommandTests(object):
         """
         env = dict(os.environ)
         cmd = Command('env')
-        self.execute(cmd.user('1000:1000'))
+        runner(cmd.user('1000:1000'))
 
         out_lines, _ = captured_lines(capfd)
         cmd_env = parse_env_output(out_lines)
@@ -127,43 +141,43 @@ class _CommonCommandTests(object):
         expected_env['HOME'] = '/'
         assert_that(cmd_env, Equals(expected_env))
 
-    def test_env(self, capfd):
+    def test_env(self, capfd, runner):
         """
         When environment variables are added to a command, those variables
         should reflect in the child process when the command is run.
         """
-        self.execute(Command('env').env('FOO', 'bar'))
+        runner(Command('env').env('FOO', 'bar'))
 
         out_lines, _ = captured_lines(capfd)
         cmd_env = parse_env_output(out_lines)
         assert_that(cmd_env['FOO'], Equals('bar'))
 
-    def test_env_remove(self, capfd):
+    def test_env_remove(self, capfd, runner):
         """
         When environment variables are removed from a command, those variables
         should not be present in the child process when the command is run.
         """
         cmd = Command('env').env('FOO', 'bar')
 
-        self.execute(cmd.env_remove('FOO'))
+        runner(cmd.env_remove('FOO'))
 
         out_lines, _ = captured_lines(capfd)
         cmd_env = parse_env_output(out_lines)
         assert_that('FOO' in cmd_env, Equals(False))
 
-    def test_env_clear(self, capfd):
+    def test_env_clear(self, capfd, runner):
         """
         When environment variables are cleared from a command, no variables
         should be present in the child process when the command is run.
         """
         cmd = Command('env').env('FOO', 'bar')
 
-        self.execute(cmd.env_clear())
+        runner(cmd.env_clear())
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals([]))
 
-    def test_arg_from_env(self, capfd):
+    def test_arg_from_env(self, capfd, runner):
         """
         When a program argument is specified via an environment variable, the
         value of the argument should be determined by the environment variable
@@ -171,7 +185,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.arg_from_env('HOME')  # Pick something that should be in the env
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(os.environ['HOME']))
@@ -179,7 +193,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that('HOME' in cmd_env, Equals(False))
 
-    def test_arg_from_env_not_present(self, capfd):
+    def test_arg_from_env_not_present(self, capfd, runner):
         """
         When a program argument is specified via an environment variable, but
         the variable is not present in the environment, the argument should not
@@ -187,7 +201,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.arg_from_env('DOESNOTEXIST')
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(''))
@@ -195,7 +209,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that('DOESNOTEXIST' in cmd_env, Equals(False))
 
-    def test_arg_from_env_no_remove(self, capfd):
+    def test_arg_from_env_no_remove(self, capfd, runner):
         """
         When a program argument is specified via an environment variable, and
         the remove option is set False, the argument should be added and the
@@ -203,7 +217,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.arg_from_env('HOME', remove=False)
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(os.environ['HOME']))
@@ -211,7 +225,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that(cmd_env['HOME'], Equals(os.environ['HOME']))
 
-    def test_arg_from_env_default(self, capfd):
+    def test_arg_from_env_default(self, capfd, runner):
         """
         When a program argument is specified via an environment variable, and a
         default value is provided, then if the variable is not set, the default
@@ -219,7 +233,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.arg_from_env('DOESNOTEXIST', default='foobar')
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals('foobar'))
@@ -240,7 +254,7 @@ class _CommonCommandTests(object):
                 'argument for program "/bin/sh"'):
             Command('/bin/sh').arg_from_env('DOESNOTEXIST', required=True)
 
-    def test_opt_from_env(self, capfd):
+    def test_opt_from_env(self, capfd, runner):
         """
         When a program option is specified via an environment variable, the
         value of the option should be determined by the environment variable
@@ -248,7 +262,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.opt_from_env('--home', 'HOME')
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0),
@@ -257,7 +271,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that('HOME' in cmd_env, Equals(False))
 
-    def test_opt_from_env_not_present(self, capfd):
+    def test_opt_from_env_not_present(self, capfd, runner):
         """
         When a program option is specified via an environment variable, but the
         variable is not present in the environment, the option should not be
@@ -265,7 +279,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.opt_from_env('--home', 'DOESNOTEXIST')
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(''))
@@ -273,7 +287,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that('DOESNOTEXIST' in cmd_env, Equals(False))
 
-    def test_opt_from_env_no_remove(self, capfd):
+    def test_opt_from_env_no_remove(self, capfd, runner):
         """
         When a program option is specified via an environment variable, and the
         remove option is set False, the option should be added and the variable
@@ -281,7 +295,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.opt_from_env('--home', 'HOME', remove=False)
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0),
@@ -290,7 +304,7 @@ class _CommonCommandTests(object):
         cmd_env = parse_env_output(out_lines)
         assert_that(cmd_env['HOME'], Equals(os.environ['HOME']))
 
-    def test_opt_from_env_default(self, capfd):
+    def test_opt_from_env_default(self, capfd, runner):
         """
         When a program option is specified via an environment variable, and a
         default value is provided, then if the variable is not set, the default
@@ -298,7 +312,7 @@ class _CommonCommandTests(object):
         """
         cmd = Command('/bin/sh').args('-c', 'echo "$@" && env', '--')
         cmd.opt_from_env('--home', 'DOESNOTEXIST', default='foobar')
-        self.execute(cmd)
+        runner(cmd)
 
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals('--home foobar'))
@@ -319,22 +333,3 @@ class _CommonCommandTests(object):
                 'option "--home" for program "/bin/sh"'):
             Command('/bin/sh').opt_from_env('--home', 'DOESNOTEXIST',
                                             required=True)
-
-
-class TestCommandRun(_CommonCommandTests):
-    """ Tests for the ``Command`` class when invoking via ``run()``. """
-    def execute(self, cmd):
-        cmd.run()
-
-
-class TestCommandExec(_CommonCommandTests):
-    """ Tests for the ``Command`` class when invoking via ``exec_()``. """
-    def execute(self, cmd):
-        # Run the command in a separate process so that it can be exec-ed
-        p = Process(target=cmd.exec_)
-        p.start()
-        p.join()
-        if p.exitcode:
-            # Simulate a CalledProcessError to simplify tests
-            raise CalledProcessError(p.exitcode, [cmd._program] + cmd._args)
-        return p.exitcode

--- a/pydexec/tests/test_command.py
+++ b/pydexec/tests/test_command.py
@@ -27,7 +27,7 @@ class _CommonCommandTests(object):
 
     def execute(self, cmd):
         """ Execute the given Command object. """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     def test_stdout(self, capfd):
         """

--- a/pydexec/tests/test_command.py
+++ b/pydexec/tests/test_command.py
@@ -20,11 +20,12 @@ def parse_env_output(out_lines):
     return cmd_env
 
 
-class TestCommand(object):
+class TestCommandRun(object):
+    """ Tests for the ``Command`` class when invoking via ``run()``. """
     # Use pytest-style tests rather than testtools so that we can capture
     # stdout/stderr from the file descriptors.
 
-    def test_run_stdout(self, capfd):
+    def test_stdout(self, capfd):
         """
         When a command writes to stdout, that output should be captured and
         written to Python's stdout.
@@ -35,7 +36,7 @@ class TestCommand(object):
         assert_that(out_lines, Equals(['Hello, World!']))
         assert_that(err_lines, Equals([]))
 
-    def test_run_stderr(self, capfd):
+    def test_stderr(self, capfd):
         """
         When a command writes to stderr, that output should be captured and
         written to Python's stderr.
@@ -47,7 +48,7 @@ class TestCommand(object):
         assert_that(out_lines, Equals([]))
         assert_that(err_lines, Equals(['Hello, World!']))
 
-    def test_run_output_unicode(self, capfd):
+    def test_output_unicode(self, capfd):
         """
         When a command writes Unicode to a standard stream, that output should
         be captured and encoded correctly.
@@ -57,7 +58,7 @@ class TestCommand(object):
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['á, é, í, ó, ú, ü, ñ, ¿, ¡']))
 
-    def test_run_error(self, capfd):
+    def test_error(self, capfd):
         """
         When a command exits with a non-zero return code, an error should be
         raised with the correct information about the result of the command.
@@ -71,7 +72,7 @@ class TestCommand(object):
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines, Equals(['errored']))
 
-    def test_run_preserves_environment(self, capfd):
+    def test_preserves_environment(self, capfd):
         """
         When a command is run, the environment variables of the parent process
         are preserved.
@@ -85,7 +86,7 @@ class TestCommand(object):
         assert_that(cmd_env, Equals(env))
 
     @pytest.mark.skipif(os.getuid() != 0, reason='requires root')
-    def test_run_switch_user(self, capfd):
+    def test_switch_user(self, capfd):
         """
         When a user is set for the command, the user should be switched to
         before the command is run.
@@ -105,7 +106,7 @@ class TestCommand(object):
         assert_that(out_lines, Equals(['0:0:0']))
 
     @pytest.mark.skipif(os.getuid() != 0, reason='requires root')
-    def test_run_switch_user_preserves_environment(self, capfd):
+    def test_switch_user_preserves_environment(self, capfd):
         """
         When a command is run and a user is set, the environment variables of
         the parent process are preserved, except for the ``HOME`` variable


### PR DESCRIPTION
This won't increase coverage because I can't get Coverage to work on a Python process that execs.
