### PR TITLE
Add ability to add arguments unless certain arguments already present

### DIFF
--- a/pydexec/tests/test_command.py
+++ b/pydexec/tests/test_command.py
@@ -321,6 +321,7 @@ class TestCommand(object):
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(''))
 
+        # The environment variable is still removed even if not used
         cmd_env = parse_env_output(out_lines)
         assert_that('HOME' in cmd_env, Equals(False))
 
@@ -431,6 +432,7 @@ class TestCommand(object):
         out_lines, _ = captured_lines(capfd)
         assert_that(out_lines.pop(0), Equals(''))
 
+        # The environment variable is still removed even if not used
         cmd_env = parse_env_output(out_lines)
         assert_that('HOME' in cmd_env, Equals(False))
 


### PR DESCRIPTION
The main use case for this is things that can be configured using either environment variables or via CLI arguments, where the CLI argument takes priority. Another use case is setting a certain option/argument by default unless the user has provided that same option.

For example, in django-bootstrap, we want to provide some nice default options for Celery and we set a bunch of arguments/options. Something like...
```shell
...
exec su-exec celery \
  celery worker \
    --pidfile /var/run/celery/worker.pid \
    --app "$CELERY_APP" \
    ${CELERY_BROKER:+--broker "$CELERY_BROKER"} \
    --loglevel "${CELERY_LOGLEVEL:-INFO}" \
    --concurrency "${CELERY_CONCURRENCY:-1}"
    "$@"
```

But what if some of those options are provided via `$@` already? Also, some have short forms of the option, e.g. `-A` == `--app`.

This would allow something like this:
```python
import sys

from pydexec.command import Command

...

cmd = Command('celery').user('celery').args(sys.argv[1:])
(cmd.args('--pidfile', '/var/run/celery/worker.pid', unless_args=['--pidfile'])
    .opt_from_env('--app', 'CELERY_APP', required=True,
                  unless_args=['--app', '-A'])
    .opt_from_env('--broker', 'CELERY_BROKER', unless_args=['--broker', '-b'])
    .opt_from_env('--loglevel', 'CELERY_LOGLEVEL', default='INFO',
                  unless_args=['--loglevel', '-l'])
    .opt_from_env('--concurrency', 'CELERY_CONCURRENCY', default='1',
                  unless_args=['--concurrency', '-c']))
```
...where default options and options from environment variables are only set if they aren't already.

One flaw to this is if the user uses the `--opt=value` format, like `--loglevel=WARN`, then this system wouldn't be very effective :-/